### PR TITLE
Rely on passed value state from props, trigger onChange in selectItem

### DIFF
--- a/src/components/NacelleLinker.js
+++ b/src/components/NacelleLinker.js
@@ -128,8 +128,7 @@ Interface.propTypes = {
   children: PropTypes.node
 }
 
-const NacelleLinker = ({ type, onChange }) => {
-  const [handle, setHandle] = useState('')
+const NacelleLinker = ({ type, onChange, value }) => {
   const [searchOptions, setSearchOptions] = useState([])
   const [searchQuery, setSearchQuery] = useState(null)
   const [activeTab, setActiveTab] = useState(0)
@@ -137,8 +136,10 @@ const NacelleLinker = ({ type, onChange }) => {
   const onClose = useCallback(() => setInerfaceOpen(false), [])
   const onQueryUpdate = useCallback((query) => setSearchQuery(query), [])
 
+  const handle = value || ''
+
   const selectItem = (handle) => {
-    setHandle(handle)
+    onChange(createPatchFrom(handle))
     onClose()
   }
 
@@ -161,13 +162,7 @@ const NacelleLinker = ({ type, onChange }) => {
         </Heading>
         <Box>
           <Inline space={[4]} style={{ marginTop: '1em' }}>
-            <TextInput
-              value={handle}
-              onChange={(event) =>
-                onChange(createPatchFrom(event.target.value))
-              }
-              disabled
-            />
+            <TextInput value={handle} disabled />
             <Button
               fontSize={[2, 2, 3]}
               mode="ghost"
@@ -234,7 +229,8 @@ NacelleLinker.propTypes = {
       dataType: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
     })
   }).isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string
 }
 
 export default React.forwardRef((props, ref) => (

--- a/src/components/NacelleLinker.js
+++ b/src/components/NacelleLinker.js
@@ -164,6 +164,7 @@ const NacelleLinker = ({ type, onChange, value, markers, level, readOnly }) => {
           header="Indexed PIM Data"
           id="dialog-example"
           onClose={onClose}
+          width={1}
           zOffset={1000}
         >
           <HandleContext.Provider value={{ handle, setHandle: selectItem }}>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Input component didnt trigger `onChange` when a handle was selected. Also used internal state instead of relying on the stored document field state.

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

Remove state handling for `handle` instead delegating to `props.value`.
Trigger  `onChange` handler in  `selectItem` intead of the disabled text inputs change handler.
Respect `readOnly` state, which might be set in the users schema for this field.
Bring layout and design more into line with built-in component, also respecting the fields potential `description`.
Set a width on the Dialog, so it renders better.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
