### PR TITLE
wip: updates queries and options to support Warp 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # these go in your Sanity Studio project's .env.development / .env.production
-SANITY_STUDIO_NACELLE_SPACE_ID=your-nacelle-space-id
+SANITY_STUDIO_NACELLE_ENDPOINT=your-nacelle-endpoint
 SANITY_STUDIO_NACELLE_SPACE_TOKEN=your-nacelle-graphql-token

--- a/config.dist.json
+++ b/config.dist.json
@@ -1,6 +1,6 @@
 {
-  "nacelleSpaceId": "",
   "nacelleSpaceToken": "",
   "nacelleSpaceIds": [],
-  "nacelleSpaceTokens": []
+  "nacelleSpaceTokens": [],
+  "nacelleEndpoint": ""
 }

--- a/src/components/Entry.js
+++ b/src/components/Entry.js
@@ -17,22 +17,22 @@ Thumb.propTypes = {
 const Entry = ({ item }) => {
   const { setHandle } = useContext(HandleContext)
   const { searchQuery, setSearchQuery } = useContext(SearchQueryContext)
-  const hidden = searchQuery ? !item.title.includes(searchQuery) : false
+  const hidden = searchQuery ? !item.content.title.includes(searchQuery) : false
 
   return (
     <MenuItem
       paddingX={2}
       onClick={() => {
-        setHandle(item.handle)
+        setHandle(item.content.handle)
         setSearchQuery(null)
       }}
       style={{ display: hidden ? 'none' : null }}
     >
       <Flex>
-        {item.featuredMedia && <Thumb src={item.featuredMedia.thumbnailSrc} />}
+        {item.content.featuredMedia && <Thumb src={item.content.featuredMedia.thumbnailSrc} />}
         <Box padding={3} flex={1}>
           <Text size={2}>
-            {item.title} <span style={{ color: '#89a' }}>({item.handle})</span>
+            {item.content.title} <span style={{ color: '#89a' }}>({item.content.handle})</span>
           </Text>
         </Box>
       </Flex>

--- a/src/components/Gallery.js
+++ b/src/components/Gallery.js
@@ -17,7 +17,7 @@ const Gallery = ({ data, active }) => {
     >
       <Menu space={1} style={{ marginTop: '1rem' }}>
         {data &&
-          data.map((item) => <Entry item={item} key={item.globalHandle} />)}
+          data.map((item) => <Entry item={item} key={item.nacelleEntryId} />)}
       </Menu>
     </Container>
   )

--- a/src/components/NacelleDataFetcher.js
+++ b/src/components/NacelleDataFetcher.js
@@ -5,9 +5,23 @@ import { useHailFrequency, useInterval } from '../hooks'
 import { SearchOptionsContext } from '../context'
 import Gallery from './Gallery'
 
-const NacelleResults = ({ query, options, dataHandler, first, after, active }) => {
-
-  const data = useHailFrequency({ query, options, dataHandler, first, after })
+const NacelleResults = ({
+  query,
+  options,
+  dataHandler,
+  first,
+  after,
+  active,
+  type
+}) => {
+  const data = useHailFrequency({
+    query,
+    options,
+    dataHandler,
+    first,
+    after,
+    type
+  })
   const { setSearchOptions } = useContext(SearchOptionsContext)
   const [ellipses, setEllipses] = useState('.')
 
@@ -23,13 +37,13 @@ const NacelleResults = ({ query, options, dataHandler, first, after, active }) =
         data &&
           data.map((entry) => ({
             ...entry,
-            value: entry.title
+            value: entry.content.title
           }))
       )
     }
   }, [data, active, setSearchOptions])
 
-  return data && data.length ? (
+  return data ? (
     <Gallery data={data} active={active} />
   ) : (
     <p>Loading{ellipses}</p>
@@ -42,7 +56,8 @@ NacelleResults.propTypes = {
   dataHandler: PropTypes.func,
   first: PropTypes.number,
   after: PropTypes.string,
-  active: PropTypes.bool
+  active: PropTypes.bool,
+  type: PropTypes.oneOf(['products', 'productCollections']).isRequired
 }
 
 export default NacelleResults

--- a/src/components/NacelleLinker.js
+++ b/src/components/NacelleLinker.js
@@ -35,7 +35,6 @@ const createPatchFrom = (value) =>
 
 const NacelleData = ({ dataType, active }) => {
   const { spaceOptions } = useContext(SpaceOptionsContext)
-
   switch (dataType) {
     case 'products':
       return (
@@ -44,6 +43,7 @@ const NacelleData = ({ dataType, active }) => {
           options={spaceOptions}
           className="tabContent"
           active={active}
+          type="products"
         />
       )
     case 'collections':
@@ -53,6 +53,7 @@ const NacelleData = ({ dataType, active }) => {
           options={spaceOptions}
           className="tabContent"
           active={active}
+          type="productCollections"
         />
       )
   }
@@ -161,11 +162,11 @@ const NacelleLinker = ({ type, onChange, value, markers, level, readOnly }) => {
 
   useEffect(() => {
     if (!spaceOptions) {
-      const initialSpace =
-        Array.isArray(config.nacelleSpaces) &&
-        config.nacelleSpaces.find(
-          (s) => s.spaceId && s.spaceToken && s.spaceName
-        )
+      const initialSpace = Array.isArray(config.nacelleSpaces)
+        ? config.nacelleSpaces.find(
+            (s) => s.spaceId && s.spaceToken && s.spaceName
+          )
+        : {}
       setSpaceOptions(initialSpace)
     }
   }, [spaceOptions])
@@ -176,15 +177,15 @@ const NacelleLinker = ({ type, onChange, value, markers, level, readOnly }) => {
 
   const filterOption = (query, option) => {
     const queryText = query.toLowerCase().trim()
-    const titleMatch = option.title.toLowerCase().includes(queryText)
-    const handleMatch = option.handle.replace('/-/g', '').includes(queryText)
+    const titleMatch = option.content.title.toLowerCase().includes(queryText)
+    const handleMatch = option.content.handle.replace('/-/g', '').includes(queryText)
     const tagsMatch =
       Array.isArray(option.tags) &&
       option.tags.find((tag) => tag.toLowerCase().includes(queryText))
     const variantsMatch =
       Array.isArray(option.variants) &&
       option.variants.find((variant) => {
-        const titleMatch = variant.title.toLowerCase().includes(queryText)
+        const titleMatch = variant.content.title.toLowerCase().includes(queryText)
         const skuMatch =
           variant.sku &&
           variant.sku.toLowerCase().replace('/-/g', '').includes(queryText)
@@ -308,7 +309,7 @@ NacelleLinker.propTypes = {
     })
   }).isRequired,
   onChange: PropTypes.func.isRequired,
-  markers: PropTypes.arrayOf.any,
+  markers: PropTypes.any,
   level: PropTypes.number,
   value: PropTypes.string,
   readOnly: PropTypes.bool

--- a/src/hooks/useHailFrequency.js
+++ b/src/hooks/useHailFrequency.js
@@ -9,9 +9,10 @@ async function fetchFromHailFrequency({
   first,
   nextToken,
   spaceId,
-  spaceToken
+  spaceToken,
+  endpoint
 }) {
-  return await fetch('https://hailfrequency.com/v2/graphql', {
+  return await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -25,38 +26,37 @@ async function fetchFromHailFrequency({
   }).then((res) => res.json())
 }
 
-async function fetcher(query, spaceId, spaceToken) {
+async function fetcher(query, spaceId, spaceToken, endpoint, type) {
   let data = []
   let nextToken = ''
-  let page = 1
-
-  while (page === 1 || nextToken) {
+  // fetch the data as long as there's more
+  // use a do_while loop since we need to fetch at least 1 time
+  do {
     const res = await fetchFromHailFrequency({
       query,
       first: 1000,
-      nextToken,
       spaceId,
-      spaceToken
+      spaceToken,
+      nextToken,
+      endpoint
     })
 
-    if (res && res.data) {
-      const queryName = Object.keys(res.data).shift() // e.g. 'getProducts'
-      const queryResults = res.data[queryName]
+    let queryResults = res?.data?.[type]
 
-      if (queryResults && queryResults.items && queryResults.items.length) {
-        data.push(...queryResults.items)
-        nextToken = queryResults.nextToken
+    if (queryResults?.length) {
+      data.push(...queryResults)
+      // since Warp2 currently doesn't have a nextToken,
+      // if we get back as many entries as we requested, set the afterto the id of the last entry
+      if (queryResults.length == 1000) {
+        nextToken = queryResults[999]?.nacelleEntryId
       } else {
         nextToken = ''
       }
-
-      page += 1
     } else {
       nextToken = ''
     }
-  }
-
-  return data
+  } while (nextToken)
+  return data ?? []
 }
 
 /**
@@ -66,16 +66,27 @@ async function fetcher(query, spaceId, spaceToken) {
  * @param {function(Object[]):Object[]} params.dataHandler - params.dataHandler - Data handler function that can be used to transform data returned from Nacelle's indices
  * @returns {Object[]} The data stored in Nacelle's indices
  */
-export const useHailFrequency = ({ query, options, dataHandler = (data) => data }) => {
-
+export const useHailFrequency = ({
+  query,
+  options,
+  type,
+  dataHandler = (data) => data
+}) => {
   let spaceId =
     config.nacelleSpaceId || process.env.SANITY_STUDIO_NACELLE_SPACE_ID
   let spaceToken =
     config.nacelleSpaceToken || process.env.SANITY_STUDIO_NACELLE_SPACE_TOKEN
-  if(options && options.spaceId) spaceId = options.spaceId
-  if(options && options.spaceToken) spaceToken = options.spaceToken
+  const endpoint =
+    options?.nacelleEndpoint ??
+    config.nacelleEndpoint ??
+    process.env.SANITY_STUDIO_NACELLE_ENDPOINT
+  if (options && options.spaceId) spaceId = options.spaceId
+  if (options && options.spaceToken) spaceToken = options.spaceToken
 
-  const { data, error } = useSWR([query, spaceId, spaceToken], fetcher)
+  const { data, error } = useSWR(
+    [query, spaceId, spaceToken, endpoint, type],
+    fetcher
+  )
   const [nacelleData, setNacelleData] = useState([])
 
   useEffect(() => {

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,40 +1,46 @@
 export const GET_PRODUCTS = `
-  query getProducts($first: Int, $after: String) {
-    getProducts(first: $first, after: $after) {
-      items {
-        featuredMedia {
-          thumbnailSrc
-        }
-        handle
-        globalHandle
-        title
-        tags
-        productType
-        variants{
-          title
-          sku
-        }
+query getProducts($first: Int, $after: String) {
+  products(filter: {first: $first, after: $after}) {
+  nacelleEntryId
+    content {
+      featuredMedia {
+        thumbnailSrc
       }
-      nextToken
+      handle
+      title
+    }
+      tags
+      productType
+      variants{
+        content {
+          title
+        }
+        sku
+
     }
   }
-`
+}`
 
 export const GET_COLLECTIONS = `
-  query getCollections($first: Int, $after: String) {
-    getCollections(first: $first, after: $after) {
-      nextToken
-      items {
-        featuredMedia {
-          thumbnailSrc
-        }
-        handle
-        globalHandle
-        title
-        productLists {
-          handles
-        }
-      }
+query getCollections($first: Int, $after: String) {
+	productCollections(filter: { first: $first, after: $after }) {
+		nacelleEntryId
+    content {
+      title
+      handle
     }
-  }
+		products {
+      nacelleEntryId
+			content {
+        title
+        handle
+        nacelleEntryId
+				featuredMedia {
+					id
+					thumbnailSrc
+				}
+			}
+		}
+	}
+}
 `


### PR DESCRIPTION
<!--
  ⚠️ PR Title ⚠️

  Use a Conventional Commit-style PR title.
-->

## Todo - WIP PR, please don't merge

- [ ] Allow consumers to specify multiple spaces, and handle that in the spaces dropdown
- [ ] Migrate/rename the package to the new name (TBD)

## Story

[LS-1346](https://nacelle.atlassian.net/browse/LS-1346) <!-- link to Jira story -->

## What is being changed and why?

Updates the sanity plugin to work with Warp 2 instead of Warp 1.
Note that this currently drops all support for Warp 1, since the plan is to rename/release a new major version of this plugin when Warp 2 goes stable. 

<!--
  Please provide a brief summary of the changes in the PR and any required context. Screenshots, videos, etc. are appreciated.
-->

## How to Test

The best way to test changes is by using `npm link` to use it from a Sanity project with the plugin installed. The instructions for doing that should be below:

1. Open your local fork of this project in your terminal
2. Run `npm run build` to generate the dist files for this project locally.
3. Run `npm link` to setup an npm symlink for this project
4. In the terminal, navigate to an existing Sanity project which has this plugin installed. (If you don't have one, you can follow the instructions above to create one)
5. Run `npm link @nacelle/sanity-plugin-pim-linker` - this will link the version of the `@nacelle/sanity-plugin-pim-linker` in your local Sanity Project to your local clone of this repo.
6. Update the `@config/nacelle/sanity-plugin-pim-linker.json` to use a Warp2 Url for `NacelleEndpoint` instead of `NacelleSpaceId`. Also update your `NacelleSpaceToken` accordingly.
7. Run your command to start Sanity Studio, e.g. `npm run start`. You should be able to use the fields from this plugin with the data from the Warp2 Space.
